### PR TITLE
WIP - [ConstructionService] Update /preprocess and /metadata logic

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous workflow runs
         uses: styfle/cancel-workflow-action@0.4.0

--- a/server/src/helpers/errors.ts
+++ b/server/src/helpers/errors.ts
@@ -96,7 +96,7 @@ const errors: Record<number, E> = {
   },
   [ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT]: {
     code: ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT,
-    message: 'Account address was not an SS58 address with the correct prefix',
+    message: 'Account address was not an SS58 address with a valid prefix',
     retriable: false,
   },
   [ApiError.INVALID_PUBLIC_KEY]: {

--- a/server/src/helpers/errors.ts
+++ b/server/src/helpers/errors.ts
@@ -21,6 +21,9 @@ export enum ApiError {
   NOT_AVAILABLE_OFFLINE = 609,
   UNABLE_TO_GET_BLOCK = 610,
   INVALID_ACCOUNT_ADDRESS = 611,
+  INVALID_ACCOUNT_ADDRESS_FORMAT = 612,
+  INVALID_PUBLIC_KEY = 613,
+  INVALID_CURVE_TYPE = 614,
 }
 
 const errors: Record<number, E> = {
@@ -89,6 +92,21 @@ const errors: Record<number, E> = {
   [ApiError.INVALID_ACCOUNT_ADDRESS]: {
     code: ApiError.INVALID_ACCOUNT_ADDRESS,
     message: 'Account address is invalid',
+    retriable: false,
+  },
+  [ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT]: {
+    code: ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT,
+    message: 'Account address was not an SS58 address with the correct prefix',
+    retriable: false,
+  },
+  [ApiError.INVALID_PUBLIC_KEY]: {
+    code: ApiError.INVALID_PUBLIC_KEY,
+    message: 'Public key is invalid',
+    retriable: false,
+  },
+  [ApiError.INVALID_CURVE_TYPE]: {
+    code: ApiError.INVALID_CURVE_TYPE,
+    message: 'Curve type is invalid',
     retriable: false,
   },
 };

--- a/server/src/services/ConstructionService.ts
+++ b/server/src/services/ConstructionService.ts
@@ -73,8 +73,9 @@ const constructionPreprocess = async ({ body: { operations } }: ApiRequest<Const
 
   const address: string = operations.find(({ amount: { value } }) => new BN(value).isNeg()).account.address;
 
-  const isValidAddress = checkAddress(address, 137)[0]
-  if(!isValidAddress) {
+  const isValidVaraAddress = checkAddress(address, 137)[0]
+  const isValidGearAddress = checkAddress(address, 42)[0]
+  if(!isValidVaraAddress && !isValidGearAddress) {
     throwError(ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT);
   }
 

--- a/server/src/services/ConstructionService.ts
+++ b/server/src/services/ConstructionService.ts
@@ -1,5 +1,6 @@
 import { getTxHash } from '@substrate/txwrapper-core/lib/core/construct';
-import { BN, isHex } from '@polkadot/util';
+import { BN, hexToString, isHex, u8aToHex } from '@polkadot/util';
+import { checkAddress, decodeAddress } from '@polkadot/util-crypto';
 import { deriveAddress } from '@substrate/txwrapper-core';
 import {
   AccountIdentifier,
@@ -20,6 +21,7 @@ import {
   ConstructionSubmitRequest,
   Operation,
   OperationIdentifier,
+  PublicKey,
   TransactionIdentifierResponse,
 } from 'rosetta-client';
 import { nodeRequest } from 'gear-util';
@@ -69,13 +71,26 @@ const constructionPreprocess = async ({ body: { operations } }: ApiRequest<Const
     throwError(ApiError.INVALID_OPERATIONS_LENGTH);
   }
 
-  const sender = new AccountIdentifier(
-    operations.find(({ amount: { value } }) => new BN(value).isNeg()).account.address,
-  );
+  const address: string = operations.find(({ amount: { value } }) => new BN(value).isNeg()).account.address;
 
-  const required_public_keys = [sender];
+  const isValidAddress = checkAddress(address, 137)[0]
+  if(!isValidAddress) {
+    throwError(ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT);
+  }
 
+  let senderAccountIdentifier: AccountIdentifier;
+  try {
+    const publicKey: Uint8Array = decodeAddress(address);
+    const hexPublicKey: string = u8aToHex(publicKey).toString();
+    senderAccountIdentifier = new AccountIdentifier(hexPublicKey);
+  } catch(error) {
+    throwError(ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT);
+  }
+
+  const required_public_keys: AccountIdentifier[] = [senderAccountIdentifier];
+  
   return ConstructionPreprocessResponse.constructFromObject({ required_public_keys });
+
 };
 
 /**
@@ -96,11 +111,21 @@ const constructionMetadata = async ({
   if (config.MODE.isOffline) {
     throwError(ApiError.NOT_AVAILABLE_OFFLINE);
   }
+  
   const { api } = getNetworkIdent(network_identifier);
 
-  const pk = isHex(public_keys[0].hex_bytes) ? public_keys[0].hex_bytes : `0x${public_keys[0].hex_bytes}`;
+  const sender: PublicKey = public_keys[0];
+  const publicKey: string = sender.hex_bytes;
 
-  return new ConstructionMetadataResponse(await api.getSigningInfo(pk));
+  if(!isHex(publicKey)) {
+    throwError(ApiError.INVALID_PUBLIC_KEY);
+  }
+
+  if(sender.curve_type !== "edwards25519") {
+    throwError(ApiError.INVALID_CURVE_TYPE);
+  }
+
+  return new ConstructionMetadataResponse(await api.getSigningInfo(publicKey));
 };
 
 /**

--- a/server/src/services/ConstructionService.ts
+++ b/server/src/services/ConstructionService.ts
@@ -1,5 +1,5 @@
 import { getTxHash } from '@substrate/txwrapper-core/lib/core/construct';
-import { BN, hexToString, isHex, u8aToHex } from '@polkadot/util';
+import { BN, hexAddPrefix, hexStripPrefix, isHex, u8aToHex } from '@polkadot/util';
 import { checkAddress, decodeAddress } from '@polkadot/util-crypto';
 import { deriveAddress } from '@substrate/txwrapper-core';
 import {
@@ -82,7 +82,7 @@ const constructionPreprocess = async ({ body: { operations } }: ApiRequest<Const
   let senderAccountIdentifier: AccountIdentifier;
   try {
     const publicKey: Uint8Array = decodeAddress(address);
-    const hexPublicKey: string = u8aToHex(publicKey).toString();
+    const hexPublicKey: string = hexStripPrefix(u8aToHex(publicKey).toString());
     senderAccountIdentifier = new AccountIdentifier(hexPublicKey);
   } catch(error) {
     throwError(ApiError.INVALID_ACCOUNT_ADDRESS_FORMAT);
@@ -116,7 +116,7 @@ const constructionMetadata = async ({
   const { api } = getNetworkIdent(network_identifier);
 
   const sender: PublicKey = public_keys[0];
-  const publicKey: string = sender.hex_bytes;
+  const publicKey: string = hexAddPrefix(sender.hex_bytes);
 
   if(!isHex(publicKey)) {
     throwError(ApiError.INVALID_PUBLIC_KEY);


### PR DESCRIPTION
## Description

- Updated the `/construction/preprocess` route to convert the SS58 address into a hex public key for the `required_public_keys` response field
- Added more input validation to the `/construction/preprocess` and `/construction/metadata` routes

## Testing

Local exploratory testing confirms that the `/construction/preprocess` response is properly created to be passed to the `/metadata` endpoint.