### PR TITLE
[controller] Fix bug in error handling

### DIFF
--- a/server/src/controllers/Controller.ts
+++ b/server/src/controllers/Controller.ts
@@ -21,10 +21,11 @@ export default class Controller {
 
   static sendError(response, error) {
     response.status(500);
-    if (error.error instanceof Object) {
-      response.json(error.error);
+
+    if (error instanceof Object) {
+      response.json(error);
     } else {
-      response.end(error.error || error.message);
+      response.end(error);
     }
   }
 


### PR DESCRIPTION
## Observed Issue

I noticed that the response body for errors was always being returned as plaintext without a corresponding error code. Verifying locally, this was due to the error handling in the Controller implementation -- there was an assumption that the error was a nested object when in reality the instance type check should be on `error` itself (not `error.error`).

## Testing Evidence

**master**
<img width="1493" alt="Screenshot 2023-07-26 at 4 50 05 PM" src="https://github.com/gear-foundation/integrations-rosetta-api/assets/6325996/eda0995e-ad31-4dcc-9485-600b46a96af1">

**Pull Request**
<img width="1492" alt="Screenshot 2023-07-26 at 4 52 26 PM" src="https://github.com/gear-foundation/integrations-rosetta-api/assets/6325996/aa59ff3d-917e-441c-ba11-1b7fbb87c766">
