### PR TITLE
[construction] Add support for balances.transfer

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 18.x
 
-      - name: Download Gear node
+      - name: Download Gear node [release=build]
         run: wget -O ./gear https://github.com/gear-tech/gear/releases/download/build/gear
 
       - name: Build spec

--- a/config/gear-testnet.json
+++ b/config/gear-testnet.json
@@ -1,7 +1,7 @@
 {
   "name": "gear_testnet",
   "blockchain": "gear",
-  "network": "gear testnet",
+  "network": "testnet",
   "wsAddress": "wss://archive-node.gear-tech.io",
   "httpAddress": "https://archive-node.gear-tech.io",
   "ss58Format": 42,

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "watch:vara": "nodemon src/index.ts --config-name vara",
     "watch:vara-test": "nodemon src/index.ts --config-name vara_testnet",
     "watch:offline": "nodemon src/index.ts --mode offline",
-    "build": "rm -rf dist && tsc"
+    "build": "rm -rf dist && tsc",
+    "lint": "yarn run eslint src/**/*.ts"
   },
   "keywords": [
     "openapi-generator",
@@ -47,6 +48,7 @@
     "winston": "3.10.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "latest",
     "@typescript-eslint/parser": "^6.2.0",
     "axios": "^1.4.0",
     "chai": "^5.0.0-alpha.1",

--- a/server/src/helpers/construct-tx.ts
+++ b/server/src/helpers/construct-tx.ts
@@ -6,44 +6,73 @@ import logger from '../logger';
 import { GearNetworkIdentifier } from '../networks';
 
 export interface TxParams {
-  dest: string;
+  fromAddress: string;
+  toAddress: string;
   value: string;
-  source: string;
   blockHash: string;
   blockNumber: number;
   eraPeriod: number;
   nonce: number;
+  tip: number;
+  specVersion: number;
+  transactionVersion: number;
+  disableKeepAlive: boolean,
   networkIdent: GearNetworkIdentifier;
 }
 
 export function constructTx({
-  dest,
+  fromAddress,
+  toAddress,
   value,
-  source,
   blockHash,
   blockNumber,
   eraPeriod,
   nonce,
-  networkIdent: { genesis, registry, specVersion, transactionVersion, metadataRpc, ss58Format },
+  tip,
+  specVersion,
+  transactionVersion,
+  disableKeepAlive,
+  networkIdent: { genesis, registry, metadataRpc, ss58Format },
 }: TxParams) {
-  const unsigned = methods.balances.transferKeepAlive(
-    { dest: { id: dest }, value },
-    {
-      address: deriveAddress(source, ss58Format),
-      blockHash,
-      blockNumber,
-      eraPeriod,
-      nonce,
-      genesisHash: genesis,
-      metadataRpc: metadataRpc,
-      specVersion,
-      transactionVersion,
-    },
-    {
-      metadataRpc: metadataRpc,
-      registry,
-    },
-  );
+  const unsigned = disableKeepAlive
+    ? methods.balances.transfer(
+      { dest: { id: toAddress }, value },
+      {
+        address: deriveAddress(fromAddress, ss58Format),
+        blockHash,
+        blockNumber,
+        eraPeriod,
+        nonce,
+        tip,
+        genesisHash: genesis,
+        metadataRpc: metadataRpc,
+        specVersion,
+        transactionVersion,
+      },
+      {
+        metadataRpc: metadataRpc,
+        registry,
+      },
+    )
+    : methods.balances.transferKeepAlive(
+      { dest: { id: toAddress }, value },
+      {
+        address: deriveAddress(fromAddress, ss58Format),
+        blockHash,
+        blockNumber,
+        eraPeriod,
+        nonce,
+        tip,
+        genesisHash: genesis,
+        metadataRpc: metadataRpc,
+        specVersion,
+        transactionVersion,
+      },
+      {
+        metadataRpc: metadataRpc,
+        registry,
+      },
+    );
 
   const loggedUnsignedTx = unsigned;
   loggedUnsignedTx.metadataRpc = "0x...truncated...";

--- a/server/src/helpers/construct-tx.ts
+++ b/server/src/helpers/construct-tx.ts
@@ -34,45 +34,26 @@ export function constructTx({
   disableKeepAlive,
   networkIdent: { genesis, registry, metadataRpc, ss58Format },
 }: TxParams) {
+  const args = { dest: { id: toAddress }, value };
+  const info = {
+        address: deriveAddress(fromAddress, ss58Format),
+        blockHash,
+        blockNumber,
+        eraPeriod,
+        nonce,
+        tip,
+        genesisHash: genesis,
+        metadataRpc: metadataRpc,
+        specVersion,
+        transactionVersion,
+    };
+  const options = {
+      metadataRpc: metadataRpc,
+      registry,
+    };
   const unsigned = disableKeepAlive
-    ? methods.balances.transfer(
-      { dest: { id: toAddress }, value },
-      {
-        address: deriveAddress(fromAddress, ss58Format),
-        blockHash,
-        blockNumber,
-        eraPeriod,
-        nonce,
-        tip,
-        genesisHash: genesis,
-        metadataRpc: metadataRpc,
-        specVersion,
-        transactionVersion,
-      },
-      {
-        metadataRpc: metadataRpc,
-        registry,
-      },
-    )
-    : methods.balances.transferKeepAlive(
-      { dest: { id: toAddress }, value },
-      {
-        address: deriveAddress(fromAddress, ss58Format),
-        blockHash,
-        blockNumber,
-        eraPeriod,
-        nonce,
-        tip,
-        genesisHash: genesis,
-        metadataRpc: metadataRpc,
-        specVersion,
-        transactionVersion,
-      },
-      {
-        metadataRpc: metadataRpc,
-        registry,
-      },
-    );
+    ? methods.balances.transfer(args, info, options)
+    : methods.balances.transferKeepAlive(args, info, options);
 
   const loggedUnsignedTx = unsigned;
   loggedUnsignedTx.metadataRpc = "0x...truncated...";

--- a/server/src/helpers/gear.ts
+++ b/server/src/helpers/gear.ts
@@ -1,6 +1,6 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { ApiDecoration } from '@polkadot/api/types';
-import { Header, Index, SignedBlock, SyncState } from '@polkadot/types/interfaces';
+import { Header, Index, SignedBlock } from '@polkadot/types/interfaces';
 import { BlockIdentifier, Peer, SyncStatus } from 'rosetta-client';
 
 import { NetworkConfig } from 'types';
@@ -95,11 +95,17 @@ export class GearApi {
     const blockHash = await this.api.rpc.chain.getBlockHash(signingInfo.header.number.unwrap());
     const eraPeriod = signingInfo.mortalLength;
 
+    const runtimeInfo = this.api.runtimeVersion;
+    const specVersion: number = runtimeInfo.specVersion.toNumber();
+    const transactionVersion: number = runtimeInfo.transactionVersion.toNumber();
+
     return {
       nonce,
       blockHash,
       blockNumber,
       eraPeriod,
+      specVersion,
+      transactionVersion
     };
   }
 

--- a/server/src/services/ConstructionService.ts
+++ b/server/src/services/ConstructionService.ts
@@ -134,7 +134,16 @@ const constructionMetadata = async ({
 const constructionPayloads = async ({
   body: { operations, network_identifier, metadata },
 }: ApiRequest<ConstructionPayloadsRequest>) => {
-  const { nonce, blockHash, blockNumber, eraPeriod } = metadata;
+  const {
+    blockHash,
+    blockNumber,
+    eraPeriod,
+    nonce,
+    tip,
+    specVersion,
+    transactionVersion,
+    disableKeepAlive
+  } = metadata;
 
   const networkIdent = getNetworkIdent(network_identifier);
 
@@ -147,17 +156,21 @@ const constructionPayloads = async ({
 
   const { value } = toOp.amount;
 
-  const dest = toOp.account.address;
-  let source = fromOp.account.address;
+  const fromAddress = fromOp.account.address;
+  const toAddress = toOp.account.address;
 
   const txParams = {
-    dest,
+    fromAddress,
+    toAddress,
     value,
-    source,
     blockHash,
     blockNumber,
     eraPeriod,
     nonce,
+    tip,
+    specVersion,
+    transactionVersion,
+    disableKeepAlive
   };
 
   const { unsignedTx, signingPayload } = constructTx({
@@ -167,7 +180,7 @@ const constructionPayloads = async ({
 
   const payloads = [
     {
-      account_identifier: new AccountIdentifier(source),
+      account_identifier: new AccountIdentifier(fromAddress),
       hex_bytes: signingPayload,
       signature_type: 'ed25519',
     },

--- a/test/development/gear.ros
+++ b/test/development/gear.ros
@@ -1,6 +1,6 @@
 create_account(1){
   create{
-    network = {"network":"Development", "blockchain":"Gear"};
+    network = {"network":"development", "blockchain":"gear"};
     key = generate_key({"curve_type": "edwards25519"});
     account = derive({
       "network_identifier": {{network}},
@@ -16,7 +16,7 @@ create_account(1){
 
 transfer(1){
   transfer{
-    transfer.network = {"network":"Development", "blockchain":"Gear"};
+    transfer.network = {"network":"development", "blockchain":"gear"};
     currency = {"symbol":"GRT", "decimals":12};
 
     sender = find_balance({

--- a/test/testnet/gear.ros
+++ b/test/testnet/gear.ros
@@ -1,6 +1,6 @@
 create_account(1){
   create{
-    network = {"network":"Gear Staging Testnet V7", "blockchain":"Gear"};
+    network = {"network":"testnet", "blockchain":"gear"};
     key = generate_key({"curve_type": "edwards25519"});
     account = derive({
       "network_identifier": {{network}},
@@ -16,7 +16,7 @@ create_account(1){
 
 transfer(1){
   transfer{
-    transfer.network = {"network":"Gear Staging Testnet V7", "blockchain":"Gear"};
+    transfer.network = {"network":"testnet", "blockchain":"gear"};
     currency = {"symbol":"GRT", "decimals":12};
 
     sender = find_balance({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,7 +1660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -1671,7 +1671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.4.0":
+"@eslint-community/regexpp@npm:^4.4.0, @eslint-community/regexpp@npm:^4.5.1":
   version: 4.6.2
   resolution: "@eslint-community/regexpp@npm:4.6.2"
   checksum: a3c341377b46b54fa228f455771b901d1a2717f95d47dcdf40199df30abc000ba020f747f114f08560d119e979d882a94cf46cfc51744544d54b00319c0f2724
@@ -2491,7 +2491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7":
+"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7":
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
   checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
@@ -2549,6 +2549,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "@types/semver@npm:7.5.0"
+  checksum: 0a64b9b9c7424d9a467658b18dd70d1d781c2d6f033096a6e05762d20ebbad23c1b69b0083b0484722aabf35640b78ccc3de26368bcae1129c87e9df028a22e2
+  languageName: node
+  linkType: hard
+
 "@types/send@npm:*":
   version: 0.17.1
   resolution: "@types/send@npm:0.17.1"
@@ -2574,6 +2581,32 @@ __metadata:
   version: 1.3.2
   resolution: "@types/triple-beam@npm:1.3.2"
   checksum: dd7b4a563fb710abc992e5d59eac481bed9e303fada2e276e37b00be31c392e03300ee468e57761e616512872e77935f92472877d0704a19688d15a726cee17b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/eslint-plugin@npm:latest":
+  version: 6.3.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.3.0"
+  dependencies:
+    "@eslint-community/regexpp": ^4.5.1
+    "@typescript-eslint/scope-manager": 6.3.0
+    "@typescript-eslint/type-utils": 6.3.0
+    "@typescript-eslint/utils": 6.3.0
+    "@typescript-eslint/visitor-keys": 6.3.0
+    debug: ^4.3.4
+    graphemer: ^1.4.0
+    ignore: ^5.2.4
+    natural-compare: ^1.4.0
+    natural-compare-lite: ^1.4.0
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependencies:
+    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 1493c6c661993640eef56893a7919cb964165cb46653c62468e71ce02a5ec8c654dd7e9767587aea67ec16c026a5630011bc7ea6c04e2fa8a4afee7f26a51358
   languageName: node
   linkType: hard
 
@@ -2605,10 +2638,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.3.0"
+  dependencies:
+    "@typescript-eslint/types": 6.3.0
+    "@typescript-eslint/visitor-keys": 6.3.0
+  checksum: 1690465f620f2b4517d45516864ef107258b2b608293d72606d0f115e11a8c1416b3d57e1b67f1daa1838f0239f71464aead57fe77c53ebd54b0aeee5fd4cf5e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/type-utils@npm:6.3.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 6.3.0
+    "@typescript-eslint/utils": 6.3.0
+    debug: ^4.3.4
+    ts-api-utils: ^1.0.1
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: cf2ab9d576bc9f3c0554318d20cb92671e4f46a07c24271fc47f144139b3843dab54592ee2e0962f81ad588f57a0b0a7c09d7e1047c720143a54bb1ec3ac4007
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:6.2.0":
   version: 6.2.0
   resolution: "@typescript-eslint/types@npm:6.2.0"
   checksum: 81878866cf7f49dbc335cce05adfbd994f348e2ebe9538fd6e934fa82e44186c16b2112b8d5f9f4c528ea127be157185be5e35e4913db4880d20ac495785baaf
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/types@npm:6.3.0"
+  checksum: 3c133e4c1b06d009739f1a4387831eb99758ba45b06b6f632fe9cf14c2839fc92dcbdbb6d94ca42c1cb5ab4ca1b31a5ead50a72e0a084b62e4de15255c451160
   languageName: node
   linkType: hard
 
@@ -2630,6 +2697,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.3.0"
+  dependencies:
+    "@typescript-eslint/types": 6.3.0
+    "@typescript-eslint/visitor-keys": 6.3.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: b2bb03411a5d079a9fd3310eec0af3b81a99827569cb3957724071aa54ac6c88449fbd1ebb72d7a356d5994d7e9542b5292a385ca3c3b0bc8049bb61a40a8ae9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/utils@npm:6.3.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.3.0
+    "@typescript-eslint/types": 6.3.0
+    "@typescript-eslint/typescript-estree": 6.3.0
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 98a078a3948e8b6a45dec8f3be9bcb72dc98faa2fe84336b1925efb7caa06c05a2fbf7290cddb420465b415cc05252548e2b839b9311f99bce84cf856fd32888
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:6.2.0":
   version: 6.2.0
   resolution: "@typescript-eslint/visitor-keys@npm:6.2.0"
@@ -2637,6 +2739,16 @@ __metadata:
     "@typescript-eslint/types": 6.2.0
     eslint-visitor-keys: ^3.4.1
   checksum: b400c657c7e5c65b289304f6f5cee6536f23b3441306f82aff2d2e047e13770330715d4f7b29e734b0b2dab6030e41028894d5cd441696115bfea43ad18b2c54
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.3.0"
+  dependencies:
+    "@typescript-eslint/types": 6.3.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: fc3148c3284de3f42724736f312a4fd0c3c2029617ae2ea9a84cf6601d31f600ee6563f9288de162028ffffde85b58d92feaafbe75a2da863ff2c4e3a0b5ed8c
   languageName: node
   linkType: hard
 
@@ -4913,7 +5025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0, ignore@npm:^5.2.4":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
@@ -5880,6 +5992,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"natural-compare-lite@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare-lite@npm:1.4.0"
+  checksum: 5222ac3986a2b78dd6069ac62cbb52a7bf8ffc90d972ab76dfe7b01892485d229530ed20d0c62e79a6b363a663b273db3bde195a1358ce9e5f779d4453887225
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -6668,6 +6787,7 @@ __metadata:
     "@polkadot/util": ^12.2.1
     "@substrate/txwrapper-core": 7.0.1
     "@substrate/txwrapper-polkadot": 7.0.1
+    "@typescript-eslint/eslint-plugin": latest
     "@typescript-eslint/parser": ^6.2.0
     axios: ^1.4.0
     body-parser: 1.20.2


### PR DESCRIPTION
## Summary

* Added support for leveraging `balances.transfer` instead of `balances.transferKeepAlive`.
* Updated network names for Gear blockchain in Rosetta specs to align with Vara naming (mainnet, testnet, etc.)

## Example Transaction

`balances.transferKeepAlive`
https://copyvara-explorer.vara-network.io/mini-vara/extrinsic/2837231-1

`balances.transfer`
https://copyvara-explorer.vara-network.io/mini-vara/extrinsic/2837524-1