### PR TITLE
[construction] Support public_keys in /construction/metadata options

### DIFF
--- a/server/src/helpers/errors.ts
+++ b/server/src/helpers/errors.ts
@@ -21,6 +21,7 @@ export enum ApiError {
   NOT_AVAILABLE_OFFLINE = 609,
   UNABLE_TO_GET_BLOCK = 610,
   INVALID_ACCOUNT_ADDRESS = 611,
+  PUBLIC_KEY_NOT_PROVIDED = 612,
   UNHANDLED_ERROR = 99999
 }
 
@@ -95,6 +96,11 @@ const errors: Record<number, RosettaError> = {
   [ApiError.INVALID_ACCOUNT_ADDRESS]: {
     code: ApiError.INVALID_ACCOUNT_ADDRESS,
     message: 'Account address is invalid',
+    retriable: false,
+  },
+  [ApiError.PUBLIC_KEY_NOT_PROVIDED]: {
+    code: ApiError.PUBLIC_KEY_NOT_PROVIDED,
+    message: 'No public key was provided',
     retriable: false,
   }
 };

--- a/server/src/services/ConstructionService.ts
+++ b/server/src/services/ConstructionService.ts
@@ -92,16 +92,33 @@ const constructionPreprocess = async ({ body: { operations } }: ApiRequest<Const
  * returns ConstructionMetadataResponse
  * */
 const constructionMetadata = async ({
-  body: { network_identifier, public_keys },
+  body: { network_identifier, options, public_keys },
 }: ApiRequest<ConstructionMetadataRequest>) => {
   if (config.MODE.isOffline) {
     throwError(ApiError.NOT_AVAILABLE_OFFLINE);
   }
+
   const { api } = getNetworkIdent(network_identifier);
+  
+  if (public_keys === undefined) {
+    if (options == undefined || options.public_keys === undefined) {
+      throwError(ApiError.PUBLIC_KEY_NOT_PROVIDED);
+    }
 
-  const pk = isHex(public_keys[0].hex_bytes) ? public_keys[0].hex_bytes : `0x${public_keys[0].hex_bytes}`;
+    const optionsPublicKeys = options.public_keys;
 
-  return new ConstructionMetadataResponse(await api.getSigningInfo(pk));
+    if(optionsPublicKeys.length == 0) {
+      throwError(ApiError.PUBLIC_KEY_NOT_PROVIDED);
+    }
+
+    const publicKey = isHex(optionsPublicKeys[0]) ? optionsPublicKeys[0] : `0x${optionsPublicKeys[0]}`;
+    
+    return new ConstructionMetadataResponse(await api.getSigningInfo(publicKey));
+  } else {
+    const pk = isHex(public_keys[0].hex_bytes) ? public_keys[0].hex_bytes : `0x${public_keys[0].hex_bytes}`;
+
+    return new ConstructionMetadataResponse(await api.getSigningInfo(pk));
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

Adding support for pulling the `public_keys` from the `options` in `/construction/metadata`.

## Example

### With `public_keys` provided

`POST http://localhost:8080/construction/metadata`

**Request:**
```json
{
    "network_identifier": {
        "blockchain": "vara",
        "network": "testnet"
    },
    "public_keys": [
        {
            "hex_bytes": "6b476b66796d46714234614256756e5843573639457a515244746b5a6b5551423434474234584a6e774e77716d5779524e",
            "curve_type": "edwards25519"
        }
    ]
}
```

**Response:**
```
{
    "metadata": {
        "nonce": 0,
        "blockHash": "0x2ce823ec9e56c3885c2eae5b3ef0de53b9a858cd919aa03e58d8b348249d9ff8",
        "blockNumber": 2806228,
        "eraPeriod": 105
    }
}
```

### With `public_keys` in `options`

`POST http://localhost:8080/construction/metadata`

**Request:**
```json
{
    "network_identifier": {
        "blockchain": "vara",
        "network": "testnet"
    },
    "options": {
        "public_keys": [
            "6b476b66796d46714234614256756e5843573639457a515244746b5a6b5551423434474234584a6e774e77716d5779524e"
        ]
    }
}
```

**Response:**
```
{
    "metadata": {
        "nonce": 0,
        "blockHash": "0xf8e13dda214658a1c54f866a473bd9952238011aeb61601d141a48d7c6024507",
        "blockNumber": 2806243,
        "eraPeriod": 105
    }
}
```

### Error Handling

`POST http://localhost:8080/construction/metadata`

**Request:**
```
{
    "network_identifier": {
        "blockchain": "vara",
        "network": "testnet"
    }
}
```

**Response:**
```
{
    "code": 612,
    "message": "No public key was provided",
    "retriable": false
}
```